### PR TITLE
Removed need for iframe argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,16 @@ Does not support history in Safari 2 and below.
         else
             alert('Hash changed to "' + newHash + '"');
     }
-    Hash.init(handler, document.getElementById('hidden-iframe'));
+    Hash.init(handler);
     Hash.go('abc123');
 
 The `initial` argument is a boolean that indicates whether the handler was
 called for initial state by `Hash.init` (value will be `true`), or due to
 an actual change to the hash (`false`).
 
-The `hidden-iframe` element referenced in the example should be an `<iframe>`
-element that has loaded a page on the server (a completely empty page is
-sufficient).
-
 ### jQuery plugin
 
 Also included is a jQuery plugin that simplifies the use of the Hash library.
-
-A blank HTML page (/js/blank.html) is needed for Internet Explorer 7 and below
-support. The path can be customized by editing `jquery.hash.js`.
 
 #### Example
 
@@ -47,12 +40,8 @@ support. The path can be customized by editing `jquery.hash.js`.
     $('div#log').hashchange(function (e, newHash) {
         $(this).prepend('<p>New hash: <b>"' + newHash + '"</b></p>');
     });
-    // Initialize. Here, the src of the iframe is passed in the init
-    // function. If you've got multiple libraries using this plugin, so
-    // the init function is called from them, you can also set the iframe
-    // src in the iframeSrc variable in the beginning of the code in
-    // jquery.hash.js.
-    $.hash.init('blank.html');
+    // Initialize.
+    $.hash.init();
     $.hash.go('abc123');
     // Changes hash when the anchor is clicked. Also automatically sets the
     // href attribute to "#def456", unless a second argument with a false

--- a/jquery/jquery.hash.js
+++ b/jquery/jquery.hash.js
@@ -1,5 +1,6 @@
 /*!
  * Copyright (c) 2009-2010 Andreas Blixt <andreas@blixt.org>
+ * Contributors: Simon Chester <simonches@gmail.com>
  * http://github.com/blixt/js-hash
  * MIT License: http://www.opensource.org/licenses/mit-license.php
  * 
@@ -16,12 +17,8 @@
  *     $('div#log').hashchange(function (e, newHash) {
  *         $(this).prepend('<p>New hash: <b>"' + newHash + '"</b></p>');
  *     });
- *     // Initialize. Here, the src of the iframe is passed in the init
- *     // function. If you've got multiple libraries using this plugin, so
- *     // the init function is called from them, you can also set the iframe
- *     // src in the iframeSrc variable in the beginning of the code in
- *     // jquery.hash.js.
- *     $.hash.init('blank.html');
+ *     // Initialize.
+ *     $.hash.init();
  *     $.hash.go('abc123');
  *     // Changes hash when the anchor is clicked. Also automatically sets the
  *     // href attribute to "#def456", unless a second argument with a false
@@ -33,13 +30,15 @@
  * get messed up.
  *
  * Does not support history in Safari 2 and below.
+ *
+ *
+ * Updated by Simon Chester (simonches@gmail.com) on 2011-05-16:
+ *   - Updated to reflect Hash.js no longer needing iframe argument
  */
 
 (function (jQuery, Hash) {
 var
 // Plugin settings
-iframeId = 'jquery-history',
-iframeSrc = '/js/blank.html',
 eventName = 'hashchange',
 eventDataName = 'hash.fn',
 init,
@@ -53,21 +52,12 @@ callback = function (newHash) {
 };
 
 jQuery.hash = {
-    init: function (src) {
+    init: function () {
         // init can only be called once.
         if (init) return;
         init = 1;
         
-        var iframe;
-        if (window.ActiveXObject && (!documentMode || documentMode < 8)) {
-            // Create an iframe for Internet Explorer 7 and below.
-            jQuery('body').prepend(
-                '<iframe id="' + iframeId + '" style="display:none;" ' +
-                'src="' + (src || iframeSrc) + '"></iframe>');
-            iframe = jQuery('#' + iframeId)[0];
-        }
-        
-        Hash.init(callback, iframe);
+        Hash.init(callback);
     },
 
     go: Hash.go


### PR DESCRIPTION
Removed the need for the iframe argument on Hash.init and blank.html file by generating the iframe automatically. Tested and working in IE6.

I also added sniffing for the hashchange event. Tested and working in IE8, Chrome, and Firefox.
