### PR TITLE
Fix "permission denied" error under Internet Explorer when used on a page altering document.domain

### DIFF
--- a/Hash.js
+++ b/Hash.js
@@ -70,8 +70,8 @@ getHash = function () {
     // is because the hash variable (escaped) will not match location.hash
     // (unescaped.) The only consistent option is to rely completely on
     // location.href.
-    var index = location.href.indexOf('#');
-    return (index == -1 ? '' : location.href.substr(index + 1));
+    var index = window.location.href.indexOf('#');
+    return (index == -1 ? '' : window.location.href.substr(index + 1));
 },
 
 // Used by all browsers except Internet Explorer 7 and below.


### PR DESCRIPTION
It seems that the window.location object is replaced when document.domain is altered,
holding a reference to the previous window.location and using it triggers a "permission denied"
because the code using the old object is blocked by the cross domain policy.
