### PR TITLE
Expose the getHash function

### DIFF
--- a/Hash.js
+++ b/Hash.js
@@ -201,6 +201,8 @@ return {
             window.location.hash = hash = newHash;
             callback(newHash, false);
         }
-    }
+    },
+    
+    getHash: getHash
 };
 })();


### PR DESCRIPTION
It is sometimes useful for the application to check the current hash. The getHash function is simple enough to replicate it in application code, but since it is already there, why not reuse it?
